### PR TITLE
fix: simplify CI to only check Terraform format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
           retention-days: 7
 
   # Infrastructure Validation
+  # NOTE: Terraform validation is handled by Terraform Cloud status checks
+  # This job only validates format to avoid state refresh issues during migration
   terraform-check:
     name: Validate Infrastructure Code
     runs-on: ubuntu-latest
@@ -65,49 +67,23 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Terraform Format Check
         id: fmt
         run: terraform fmt -check -recursive
-        continue-on-error: true
+        continue-on-error: false
 
-      - name: Terraform Init
-        id: init
-        run: terraform init
-
-      - name: Terraform Validate
-        id: validate
-        run: terraform validate -no-color
-
-      - name: Terraform Plan (Dry-run)
-        id: plan
-        run: terraform plan -no-color -input=false
-        continue-on-error: true
-        env:
-          TF_IN_AUTOMATION: "true"
-
-      - name: Comment PR with Terraform Plan
+      - name: Format Check Status
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
-        env:
-          PLAN: ${{ steps.plan.outputs.stdout }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
-            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
-            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-
-            <details><summary>Show Plan</summary>
-
-            \`\`\`terraform
-            ${process.env.PLAN}
-            \`\`\`
-
-            </details>
-
+            
+            **Note:** Full Terraform validation (init, validate, plan) is handled by Terraform Cloud.
+            Check the "Terraform Cloud" status check for infrastructure changes.
+            
             *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Workflow: \`${{ github.workflow }}\`*`;
 
             github.rest.issues.createComment({
@@ -116,10 +92,6 @@ jobs:
               repo: context.repo.repo,
               body: output
             })
-
-      - name: Terraform Plan Status
-        if: steps.plan.outcome == 'failure'
-        run: exit 1
 
   # Security Scanning
   security-scan:


### PR DESCRIPTION
Terraform Cloud handles all validation, plan, and apply operations.
CI now only checks format to avoid state refresh issues during migrations.
