### PR TITLE
chore: add Terraform header comments to trigger deployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,5 @@
+# Terraform configuration for Firebase Hosting infrastructure
+# Manages Firebase sites and Cloudflare DNS records for kattakath.com
 terraform {
   required_providers {
     google-beta = {


### PR DESCRIPTION
This PR adds descriptive header comments to main.tf. This change will trigger Terraform Cloud to run and deploy the Firebase infrastructure to corp-core-hub.