### PR TITLE
feat: add GA4 analytics tracking

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -44,6 +44,11 @@
     "gtm_id": "GTM-XXXXXX"
   },
 
+  "google_analytics": {
+    "enable": true,
+    "measurement_id": "G-96546S18GY"
+  },
+
   "disqus": {
     "enable": true,
     "shortname": "themefisher-template",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -55,6 +55,20 @@ const { title, meta_title, description, image, noindex, canonical } =
         <GoogleTagmanager id={config.google_tag_manager.gtm_id} />
       )
     }
+    <!-- google analytics 4 -->
+    {
+      config.google_analytics?.enable && (
+        <>
+          <script async src={`https://www.googletagmanager.com/gtag/js?id=${config.google_analytics.measurement_id}`}></script>
+          <script define:vars={{ measurementId: config.google_analytics.measurement_id }}>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', measurementId);
+          </script>
+        </>
+      )
+    }
     <!-- favicon -->
     <link rel="shortcut icon" href={config.site.favicon} />
     <!-- theme meta -->


### PR DESCRIPTION
## Summary
Adds Google Analytics 4 tracking to the website.

## Changes
- Added `google_analytics` config section in `config.json`
- Integrated gtag.js in `Base.astro` layout
- Measurement ID: `G-96546S18GY`
- Stream Name: corp-website
- Stream ID: 13322411643

## Testing
- Build passes locally
- GA4 script verified in built HTML output